### PR TITLE
Upgrade backports so Enumerable#join is removed

### DIFF
--- a/zookeeper.gemspec
+++ b/zookeeper.gemspec
@@ -20,7 +20,7 @@ This library uses version #{Zookeeper::DRIVER_VERSION} of zookeeper bindings.
 
   s.homepage    = 'https://github.com/slyphon/zookeeper'
 
-  s.add_runtime_dependency 'backports', '~> 2.5.1'
+  s.add_runtime_dependency 'backports', '~> 2.6.1'
   s.add_runtime_dependency 'logging',   '~> 1.7.2'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
This was causing bizarre behavior for me when upgrading the Zookeeper gem as discussed in #19.

It would be great to see Backports removed entirely (it's scary to monkey patch things in a huge codebase..) but this will at least remove one known problem for now.
