### PR TITLE
JRuby 1.7 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,10 @@ gemspec
 gem 'rake', '~> 0.9.0'
 
 group :test do
-  gem "rspec", "~> 2.8.0"
-  gem 'eventmachine', '1.0.0.beta.4'
+  gem "rspec" , "~> 2.11"
+  gem 'eventmachine', '1.0.0'
   gem 'evented-spec', '~> 0.9.0'
-
-  gem 'zk-server', '~> 1.0.0'
+  gem 'zk-server', '~> 1.1.4'
 end
 
 # ffs, :platform appears to be COMLETELY BROKEN so we just DO THAT HERE


### PR DESCRIPTION
fixed handle_keeper_exception as exception handling changed slightly in JRuby 1.7
