### PR TITLE
Add rbx 1.8 & 1.9 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
 env:
   - SPAWN_ZOOKEEPER='true'
 
+language: ruby
+
 rvm:
   - 1.9.3
   - 1.9.2
@@ -17,6 +19,12 @@ rvm:
   - ree
   - jruby-18mode
   - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: rbx-18mode
+    - rvm: rbx-19mode
 
 bundler_args: --without development docs coverage
 


### PR DESCRIPTION
In support of rubinius/rubinius#2006 it'd be great to test
zookeeper on Rubinius. Allowing rbx to fail is a good place
to start.

If they happen to pass, I'll submit another PR to remove the
allowed failures.

Thanks for your consideration.
