### PR TITLE
Updated for ruby-2.0.0-rc1

### DIFF
--- a/ext/zkrb.c
+++ b/ext/zkrb.c
@@ -758,7 +758,7 @@ inline static int get_self_pipe_read_fd(VALUE self) {
   rb_io_t *fptr;
   VALUE pipe_read = rb_iv_get(self, "@pipe_read");
 
-  if NIL_P(pipe_read)
+  if (NIL_P(pipe_read))
       rb_raise(rb_eRuntimeError, "@pipe_read was nil!");
 
   GetOpenFile(pipe_read, fptr);


### PR DESCRIPTION
RTEST is now a bare expression:

Thu Dec 20 18:29:54 2012  Nobuyoshi Nakada  nobu@ruby-lang.org

```
    * include/ruby/ruby.h (RTEST, NIL_P): make bare expressions without
      outermost parentheses.
```
