### PR TITLE
Fix build under FreeBSD

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -36,6 +36,7 @@ GENERATE_GVL_CODE_RB = 'generate_gvl_code.rb'
 
 file 'c' => TARBALL do
   sh "tar -zxf #{TARBALL}"
+  sh "patch -p0 < patch-zookeeper"
 end
 
 file GENERATE_GVL_CODE_RB => 'c'

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 
 HERE = File.expand_path(File.dirname(__FILE__))
 BUNDLE = Dir.glob("zkc-*.tar.gz").first
+ZKPATCH = "patch-zookeeper"
 
 BUNDLE_PATH = File.join(HERE, 'c')
 
@@ -57,7 +58,7 @@ Dir.chdir(HERE) do
     puts "Building zkc."
 
     unless File.exists?('c')
-      puts(cmd = "tar xzf #{BUNDLE} 2>&1")
+      puts(cmd = "tar xzf #{BUNDLE} 2>&1 && patch -p0 < #{ZKPATCH} 2>&1")
       raise "'#{cmd}' failed" unless system(cmd)
     end
 

--- a/ext/patch-zookeeper
+++ b/ext/patch-zookeeper
@@ -1,0 +1,24 @@
+--- c/src/zookeeper.c.orig	2013-04-22 16:20:14.000000000 -0700
++++ c/src/zookeeper.c	2013-04-22 16:21:36.000000000 -0700
+@@ -413,7 +413,9 @@
+ static int getaddrinfo_errno(int rc) { 
+     switch(rc) {
+     case EAI_NONAME:
++#ifdef EAI_NODATA
+     case EAI_NODATA:
++#endif
+         return ENOENT;
+     case EAI_MEMORY:
+         return ENOMEM;
+@@ -546,7 +548,11 @@
+             //EAI_BADFLAGS or EAI_ADDRFAMILY with AF_UNSPEC and 
+             // ai_flags as AI_ADDRCONFIG
+             if ((hints.ai_flags == AI_ADDRCONFIG) && 
++#ifdef EAI_ADDRFAMILY
+                 ((rc ==EAI_BADFLAGS) || (rc == EAI_ADDRFAMILY))) {
++#else
++                (rc ==EAI_BADFLAGS)) {
++#endif
+                 //reset ai_flags to null
+                 hints.ai_flags = 0;
+                 //retry getaddrinfo


### PR DESCRIPTION
Hi!

This patch fixes build under FreeBSD (and maybe other systems), where EAI_NODATA and EAI_ADDRFAMILY is not defined (this seems to be non-standard).  This patch is similar to what FreeBSD has in the ports system.
