### PR TITLE
add recursive attribute for delete

### DIFF
--- a/lib/zookeeper/client_methods.rb
+++ b/lib/zookeeper/client_methods.rb
@@ -109,10 +109,22 @@ module ClientMethods
   def delete(options = {})
     assert_open
     assert_keys(options,
-                :supported  => [:path, :version, :callback, :callback_context],
+                :supported  => [:path, :version, :callback, :callback_context, :recursive],
                 :required   => [:path])
 
     options[:version] ||= -1
+
+    if options[:recursive]
+      children = self.get_children(:path=>options[:path])[:children]
+      unless children.nil? || children.empty?
+        children.each do |child|
+          leaf = "#{options[:path]}/#{child}"
+          opts = options.clone
+          opts[:path]=leaf
+          delete(opts)
+        end
+      end
+    end
 
     req_id = setup_call(:delete, options)
     rc = super(req_id, options[:path], options[:version], options[:callback])


### PR DESCRIPTION
I always end up making my own recursive delete function for znodes. I decided I would build it in to the delete function directly here.

You can do:

z.create(:path=>"/test")
z.create(:path=>"/test/level1")
z.create(:path=>"/test/level1/level2")
z.delete(:path=>"/test", :recursive=>true) # => {:req_id=>12, :rc=>0} 
