### PR TITLE
Fixing dependent library compilation on FreeBSD 10

### DIFF
--- a/ext/zkrb.c
+++ b/ext/zkrb.c
@@ -83,6 +83,7 @@
 #include <inttypes.h>
 #include <time.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
 #include "common.h"
 #include "event_lib.h"


### PR DESCRIPTION
When installing the gem on ruby-1.9.3-p448 under FreeBSD 10.0, the underlying zookeeper libs fail with the following error.

```
zkrb.c:953:50: error: incomplete definition of type 'struct sockaddr_in6'
        inaddr = &((struct sockaddr_in6 *) &addr)->sin6_addr;
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
zkrb.c:953:28: note: forward declaration of 'struct sockaddr_in6'
        inaddr = &((struct sockaddr_in6 *) &addr)->sin6_addr;
                           ^
zkrb.c:954:47: error: incomplete definition of type 'struct sockaddr_in6'
        port = ((struct sockaddr_in6 *) &addr)->sin6_port;
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
zkrb.c:953:28: note: forward declaration of 'struct sockaddr_in6'
        inaddr = &((struct sockaddr_in6 *) &addr)->sin6_addr;
                           ^
zkrb.c:957:47: error: incomplete definition of type 'struct sockaddr_in'
      inaddr = &((struct sockaddr_in *) &addr)->sin_addr;
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
zkrb.c:957:26: note: forward declaration of 'struct sockaddr_in'
      inaddr = &((struct sockaddr_in *) &addr)->sin_addr;
                         ^
zkrb.c:958:44: error: incomplete definition of type 'struct sockaddr_in'
      port = ((struct sockaddr_in *) &addr)->sin_port;
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
zkrb.c:957:26: note: forward declaration of 'struct sockaddr_in'
      inaddr = &((struct sockaddr_in *) &addr)->sin_addr;
                         ^
1 warning and 4 errors generated.
*** Error code 1

Stop.
make: stopped in /usr/home/mgreen/.rvm/gems/ruby-1.9.3-p448/gems/zookeeper-1.4.6/ext
```

This pull request adds an include for netinet/in.h to provide the needed definitions. 
