### PR TITLE
Separate state mutex

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v1.4.7 
+
+  * Fixing dependent library compilation on FreeBSD 10 #53 (h/t: gogreen53)
 
 v1.4.6
 

--- a/lib/zookeeper/version.rb
+++ b/lib/zookeeper/version.rb
@@ -1,4 +1,4 @@
 module Zookeeper
-  VERSION = '1.4.6'
+  VERSION = '1.4.7'
   DRIVER_VERSION = '3.4.5'
 end


### PR DESCRIPTION
I've observed deadlocks related to forking.

Here's an example:

``` text
#<Thread:0xb166e48 sleep> alive=true priority=0
    bundle/ruby/1.8/gems/zookeeper-1.4.7/lib/zookeeper/common/queue_with_pipe.rb:59:in `pop'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/lib/zookeeper/common.rb:56:in `get_next_event'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/lib/zookeeper/common.rb:94:in `dispatch_thread_body'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/lib/zookeeper/common.rb:91:in `to_proc'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/lib/zookeeper/common.rb:20:in `initialize'


#<Thread:0xb1669e8 sleep> alive=true priority=0
    /usr/lib/ruby/1.8/monitor.rb:285:in `mon_acquire'
    /usr/lib/ruby/1.8/monitor.rb:214:in `mon_enter'
    /usr/lib/ruby/1.8/monitor.rb:240:in `synchronize'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:333:in `iterate_event_delivery'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:274:in `event_thread_body'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:261:in `to_proc'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:246:in `initialize'


#<Thread:0x30de4d8 run> [main] [current] alive=true priority=0
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:237:in `call'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:237:in `join'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:237:in `stop_event_thread'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:160:in `pause_before_fork_in_parent'
    /usr/lib/ruby/1.8/monitor.rb:242:in `synchronize'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/c_zookeeper.rb:160:in `pause_before_fork_in_parent'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/zookeeper_base.rb:202:in `pause_before_fork_in_parent'
    /usr/lib/ruby/1.8/monitor.rb:242:in `synchronize'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/ext/zookeeper_base.rb:196:in `pause_before_fork_in_parent'
    bundle/ruby/1.8/gems/zookeeper-1.4.7/lib/zookeeper/client_methods.rb:226:in `pause_before_fork_in_parent'
    bundle/ruby/1.8/gems/redis-3.0.4/lib/redis/connection/ruby.rb:49:in `to_proc'
    bundle/ruby/1.8/bundler/gems/zk-52329d54572e/lib/zk/client/threaded.rb:292:in `each'
    bundle/ruby/1.8/bundler/gems/zk-52329d54572e/lib/zk/client/threaded.rb:292:in `pause_before_fork_in_parent'
    bundle/ruby/1.8/bundler/gems/zk-52329d54572e/lib/zk/subscription.rb:50:in `call'
    bundle/ruby/1.8/bundler/gems/zk-52329d54572e/lib/zk/subscription.rb:50:in `call'
    bundle/ruby/1.8/bundler/gems/zk-52329d54572e/lib/zk/fork_hook.rb:62:in `safe_call'
    bundle/ruby/1.8/bundler/gems/zk-52329d54572e/lib/zk/fork_hook.rb:20:in `fire_prepare_hooks!'
    bundle/ruby/1.8/bundler/gems/zk-52329d54572e/lib/zk/install_fork_hooks.rb:14:in `fork'
    bundle/ruby/1.8/gems/resque-1.23.0/lib/resque/worker.rb:259:in `fork'
    bundle/ruby/1.8/gems/resque-1.23.0/lib/resque/worker.rb:141:in `work'
    bundle/ruby/1.8/gems/resque-1.23.0/lib/resque/worker.rb:133:in `loop'
    bundle/ruby/1.8/gems/resque-1.23.0/lib/resque/worker.rb:133:in `work'
    bundle/ruby/1.8/gems/resque-1.23.0/lib/resque/tasks.rb:36
```
