### PR TITLE
Apply memory leak in zoo_multi API patch

### DIFF
--- a/ext/patches/zkc-3.4.5-leak.patch
+++ b/ext/patches/zkc-3.4.5-leak.patch
@@ -1,0 +1,13 @@
+--- zkc-3.4.5/src/c/src/zookeeper.c	(revision 1439732)
++++ zkc-3.4.5/c/src/zookeeper.c	(working copy)
+@@ -1979,6 +1979,10 @@
+ 
+         deserialize_response(entry->c.type, xid, mhdr.type == -1, mhdr.err, entry, ia);
+         deserialize_MultiHeader(ia, "multiheader", &mhdr);
++        //While deserializing the response we must destroy completion entry for each operation in 
++        //the zoo_multi transaction. Otherwise this results in memory leak when client invokes zoo_multi
++        //operation.
++        destroy_completion_entry(entry);
+     }
+ 
+     return rc;


### PR DESCRIPTION
refs Issue #61.

https://issues.apache.org/jira/browse/ZOOKEEPER-1562
