### PR TITLE
@e0en contributed patch to fix build on yosemite

### DIFF
--- a/ext/patches/zkc-3.4.5-yosemite-htonl-fix.patch
+++ b/ext/patches/zkc-3.4.5-yosemite-htonl-fix.patch
@@ -1,0 +1,102 @@
+diff -ur zkc-3.4.5-orig/c/include/recordio.h zkc-3.4.5/c/include/recordio.h
+--- zkc-3.4.5-orig/c/include/recordio.h	2012-09-30 13:53:32.000000000 -0400
++++ zkc-3.4.5/c/include/recordio.h	2014-07-29 03:13:27.000000000 -0400
+@@ -73,7 +73,7 @@
+ char *get_buffer(struct oarchive *);
+ int get_buffer_len(struct oarchive *);
+ 
+-int64_t htonll(int64_t v);
++int64_t zk_htonll(int64_t v);
+ 
+ #ifdef __cplusplus
+ }
+diff -ur zkc-3.4.5-orig/c/src/recordio.c zkc-3.4.5/c/src/recordio.c
+--- zkc-3.4.5-orig/c/src/recordio.c	2012-09-30 13:53:32.000000000 -0400
++++ zkc-3.4.5/c/src/recordio.c	2014-07-29 03:13:35.000000000 -0400
+@@ -80,7 +80,7 @@
+     priv->off+=sizeof(i);
+     return 0;
+ }
+-int64_t htonll(int64_t v)
++int64_t zk_htonll(int64_t v)
+ {
+     int i = 0;
+     char *s = (char *)&v;
+@@ -98,7 +98,7 @@
+ 
+ int oa_serialize_long(struct oarchive *oa, const char *tag, const int64_t *d)
+ {
+-    const int64_t i = htonll(*d);
++    const int64_t i = zk_htonll(*d);
+     struct buff_struct *priv = oa->priv;
+     if ((priv->len - priv->off) < sizeof(i)) {
+         int rc = resize_buffer(priv, priv->len + sizeof(i));
+@@ -207,7 +207,7 @@
+     }
+     memcpy(count, priv->buffer+priv->off, sizeof(*count));
+     priv->off+=sizeof(*count);
+-    v = htonll(*count); // htonll and  ntohll do the same
++    v = zk_htonll(*count); // zk_htonll and  ntohll do the same
+     *count = v;
+     return 0;
+ }
+diff -ur zkc-3.4.5-orig/c/src/zookeeper.c zkc-3.4.5/c/src/zookeeper.c
+--- zkc-3.4.5-orig/c/src/zookeeper.c	2012-09-30 13:53:32.000000000 -0400
++++ zkc-3.4.5/c/src/zookeeper.c	2014-07-29 03:13:45.000000000 -0400
+@@ -1408,7 +1408,7 @@
+     memcpy(buffer + offset, &req->protocolVersion, sizeof(req->protocolVersion));
+     offset = offset +  sizeof(req->protocolVersion);
+ 
+-    req->lastZxidSeen = htonll(req->lastZxidSeen);
++    req->lastZxidSeen = zk_htonll(req->lastZxidSeen);
+     memcpy(buffer + offset, &req->lastZxidSeen, sizeof(req->lastZxidSeen));
+     offset = offset +  sizeof(req->lastZxidSeen);
+ 
+@@ -1416,7 +1416,7 @@
+     memcpy(buffer + offset, &req->timeOut, sizeof(req->timeOut));
+     offset = offset +  sizeof(req->timeOut);
+ 
+-    req->sessionId = htonll(req->sessionId);
++    req->sessionId = zk_htonll(req->sessionId);
+     memcpy(buffer + offset, &req->sessionId, sizeof(req->sessionId));
+     offset = offset +  sizeof(req->sessionId);
+ 
+@@ -1447,7 +1447,7 @@
+      memcpy(&req->sessionId, buffer + offset, sizeof(req->sessionId));
+      offset = offset +  sizeof(req->sessionId);
+ 
+-     req->sessionId = htonll(req->sessionId);
++     req->sessionId = zk_htonll(req->sessionId);
+      memcpy(&req->passwd_len, buffer + offset, sizeof(req->passwd_len));
+      offset = offset +  sizeof(req->passwd_len);
+ 
+diff -ur zkc-3.4.5-orig/c/tests/ZKMocks.cc zkc-3.4.5/c/tests/ZKMocks.cc
+--- zkc-3.4.5-orig/c/tests/ZKMocks.cc	2012-09-30 13:53:32.000000000 -0400
++++ zkc-3.4.5/c/tests/ZKMocks.cc	2014-07-29 03:13:59.000000000 -0400
+@@ -41,7 +41,7 @@
+     int offset=sizeof(req->protocolVersion);
+     
+     memcpy(&req->lastZxidSeen,buf.data()+offset,sizeof(req->lastZxidSeen));
+-    req->lastZxidSeen = htonll(req->lastZxidSeen);
++    req->lastZxidSeen = zk_htonll(req->lastZxidSeen);
+     offset+=sizeof(req->lastZxidSeen);
+     
+     memcpy(&req->timeOut,buf.data()+offset,sizeof(req->timeOut));
+@@ -49,7 +49,7 @@
+     offset+=sizeof(req->timeOut);
+     
+     memcpy(&req->sessionId,buf.data()+offset,sizeof(req->sessionId));
+-    req->sessionId = htonll(req->sessionId);
++    req->sessionId = zk_htonll(req->sessionId);
+     offset+=sizeof(req->sessionId);
+     
+     memcpy(&req->passwd_len,buf.data()+offset,sizeof(req->passwd_len));
+@@ -322,7 +322,7 @@
+     buf.append((char*)&tmp,sizeof(tmp));
+     tmp=htonl(timeOut);
+     buf.append((char*)&tmp,sizeof(tmp));
+-    int64_t tmp64=htonll(sessionId);
++    int64_t tmp64=zk_htonll(sessionId);
+     buf.append((char*)&tmp64,sizeof(sessionId));
+     tmp=htonl(passwd_len);
+     buf.append((char*)&tmp,sizeof(tmp));


### PR DESCRIPTION
@eric I'm confused, should `zkrb_wrapper.c` be regenerated each build? Should we remove it from `ext`?

Otherwise this patch builds for me on 10.9, care to take it for a spin?
