### PR TITLE
rewrite deprecated usage of rb_thread_select with rb_thread_fd_select

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ rvm:
   - rbx-18mode
   - rbx-19mode
   - 2.0.0
+  - 2.1.0
+  - 2.2.0
 matrix:
   allow_failures:
     - rvm: rbx-18mode

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake', '~> 0.9.0'
 
 group :test do
   gem "rspec" , "~> 2.11"
-  gem 'eventmachine', '1.0.0'
+  gem 'eventmachine', '1.0.4'
   gem 'evented-spec', '~> 0.9.0'
   gem 'zk-server', '~> 1.0', :git => 'https://github.com/zk-ruby/zk-server.git'
 end

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -68,7 +68,7 @@ Dir.chdir(HERE) do
     # clean up stupid apple rsrc fork bullshit
     FileUtils.rm_f(Dir['**/._*'].select{|p| test(?f, p)})
 
-    Dir.chdir(BUNDLE_PATH) do        
+    Dir.chdir(BUNDLE_PATH) do
       configure = "./configure --prefix=#{HERE} --with-pic --without-cppunit --disable-dependency-tracking #{$EXTRA_CONF} 2>&1"
       configure = "env CFLAGS='#{DEBUG_CFLAGS}' #{configure}" if ZK_DEBUG
 
@@ -85,13 +85,14 @@ end
 Dir.chdir("#{HERE}/lib") do
   %w[st mt].each do |stmt|
     %w[a la].each do |ext|
-      system("cp -f libzookeeper_#{stmt}.#{ext} libzookeeper_#{stmt}_gem.#{ext}") 
+      system("cp -f libzookeeper_#{stmt}.#{ext} libzookeeper_#{stmt}_gem.#{ext}")
     end
   end
 end
 $LIBS << " -lzookeeper_st_gem"
 
 have_func('rb_thread_blocking_region')
+have_func('rb_thread_fd_select')
 
 $CFLAGS << ' -Wall' if ZK_DEV
 create_makefile 'zookeeper_c'


### PR DESCRIPTION
As discussed in #72 to fix ruby2.2 compatibility while keeping backward compatibility.

I also had to bump the eventmachine dependency to include fixes for ruby 2.2 on their side. I haven't tested on ruby 1.8 yet, but I guess a CI is going to do so with this PR?