### PR TITLE
Adds build flags for illumos

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -45,7 +45,7 @@ $LIBPATH = ["#{HERE}/lib"]
 $DEFLIBPATH = []
 
 if RbConfig::CONFIG['arch'] =~ /solaris/
-  $EXTRA_CONF = "CFLAGS='-D_POSIX_PTHREAD_SEMANTICS' LDFLAGS='-lsocket -lnsl'"
+  $EXTRA_CONF = "CFLAGS='-D_POSIX_PTHREAD_SEMANTICS -pthread' LDFLAGS='-lsocket -lnsl'"
 end
 
 def safe_sh(cmd)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -44,6 +44,10 @@ $LDFLAGS = "#{$libraries} #{$LDFLAGS}"
 $LIBPATH = ["#{HERE}/lib"]
 $DEFLIBPATH = []
 
+if RbConfig::CONFIG['arch'] =~ /solaris/
+  $EXTRA_CONF = "CFLAGS='-D_POSIX_PTHREAD_SEMANTICS' LDFLAGS='-lsocket -lnsl'"
+end
+
 def safe_sh(cmd)
   puts cmd
   system(cmd)


### PR DESCRIPTION
The zookeeper gem (at v1.4.11) doesn't currently build on our illumos based (SmartOS) machines. There are three specific fixes:

Setting the CFLAG `-D_POSIX_PTHREAD_SEMANTICS` resolves this include issue:

```
src/zookeeper.c:740:8: error: too many arguments to function 'getpwuid_r'
   if (!getpwuid_r(uid, &pw, buf, sizeof(buf), &pwp)) {
        ^
In file included from src/zookeeper.c:61:0:
/usr/include/pwd.h:166:23: note: declared here
 extern struct passwd *getpwuid_r(uid_t, struct passwd *, char *, int);
                       ^
```

The usual LDFLAGS `-lsocket` fixes the inevitable socket linking errors that then crop up:

```
Undefined           first referenced
 symbol                 in file
recv                                ./.libs/libzookeeper_st.so
send                                ./.libs/libzookeeper_st.so
socket                              ./.libs/libzookeeper_st.so
setsockopt                          ./.libs/libzookeeper_st.so
getsockopt                          ./.libs/libzookeeper_st.so
connect                             ./.libs/libzookeeper_st.so
getaddrinfo                         ./.libs/libzookeeper_st.so
getpeername                         ./.libs/libzookeeper_st.so
freeaddrinfo                        ./.libs/libzookeeper_st.so
inet_ntop                           ./.libs/libzookeeper_st.so
ld: fatal: symbol referencing errors. No output written to .libs/cli_st
```

With these, the library will build, and it will _seem_ like everything is working. Until you run the test suite. Then it all wedges up during connection:

```
D, [2016-03-25T16:41:28.999115 #31215] DEBUG -- :     Zookeeper::CZookeeper: event_thread running: true
2016-03-25 16:41:28,999:31215:ZOO_ERROR@handle_socket_error_msg@1605: Socket [127.0.0.1:2181] zk retcode=-4, errno=0(Error 0): connect() call failed
DEBUG 6:zkrb.c:864: timed out waiting for descriptor to be ready. prc=-9 interest=0 fd=0 pipe_r_fd=7 maxfd=7 irc=-4 timeout=0.000000
```

Turns out this is fixed by adding the `-pthread` CFLAG to the build. And lo:

```
# bundle exec rspec 
...snip...
Finished in 11.76 seconds
319 examples, 0 failures, 7 pending
```

Note: I've tried _just_ adding the `-pthread` CFLAG and it fails to build. Both seem to be required for a clean build.
