### PR TITLE
Make use of the timeout parameter in the JavaBase initializer

### DIFF
--- a/java/java_base.rb
+++ b/java/java_base.rb
@@ -189,7 +189,7 @@ class JavaBase
       @req_registry.clear_watchers!
 
       replace_jzk!(opts)
-      wait_until_connected
+      wait_until_connected(timeout)
     end
 
     state


### PR DESCRIPTION
Hello, 
I've noticed that the `timeout` parameter that is passed to the `initializer` method of the `JavaBase` is suddenly ignored when creating a new connection. 
This results in always waiting 10 seconds before timing out when a new connection cannot be established, no matter what timeout value is given. 
I've tested it with MRI and in that case it works as expected. 