### PR TITLE
Update Travis CI Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,19 @@ env:
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 1.9.2
-  - 1.8.7
   - ree
   - jruby-18mode
   - jruby-19mode
   - rbx-18mode
   - rbx-19mode
+  - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
-  - 2.4.0
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 matrix:
   allow_failures:
     - rvm: rbx-18mode
@@ -38,4 +38,3 @@ bundler_args: --without development docs coverage
 branches:
   except:
 #     - 'dev/zookeeper-st'
-


### PR DESCRIPTION
Updated all listed Ruby versions we test against to their latest releases and added Ruby 2.5.x and Ruby 2.6.x according to [ruby-lang.org/en/downloads/releases/](https://www.ruby-lang.org/en/downloads/releases/).

No idea why [1.8.7](https://travis-ci.org/zk-ruby/zookeeper/jobs/595138290) and [1.9.2](https://travis-ci.org/zk-ruby/zookeeper/jobs/595138289) are failing to download in the Travis CI containers. Should we remove them? At this point we probably don't need to be testing against them.
<img width="343" alt="Screen Shot 2019-10-08 at 23 25 14" src="https://user-images.githubusercontent.com/1557529/66404263-1050da80-ea23-11e9-887e-0074010533d2.png">