### PR TITLE
Work around compiler errors on newer versions of gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ before_install:
 env:
   - SPAWN_ZOOKEEPER='true'
 
+# Use an old ubuntu so that old rubies are available
+dist: trusty
+
 language: ruby
 
 rvm:

--- a/ext/patches/zkc-3.4.5-buffer-overflow.patch
+++ b/ext/patches/zkc-3.4.5-buffer-overflow.patch
@@ -1,0 +1,11 @@
+--- zkc-3.4.5.orig/c/src/zookeeper.c	2020-08-13 03:04:49.631654715 -0400
++++ zkc-3.4.5/c/src/zookeeper.c	2020-08-13 03:03:24.983922697 -0400
+@@ -3411,7 +3411,7 @@
+ 
+ static const char* format_endpoint_info(const struct sockaddr_storage* ep)
+ {
+-    static char buf[128];
++    static char buf[128+6];
+     char addrstr[128];
+     void *inaddr;
+ #ifdef WIN32


### PR DESCRIPTION
Fixes #85 

Unfortunately the "fix" mentioned in the #85 thread:

> CFLAGS=-Wno-error=format-overflow gem install zookeeper --version 1.4.11

did not fix the issue for me in the context of `bundle install`, because this had the effect of setting that value of `CFLAGS` for *all* native extensions in my bundle install, not just zookeeper. This in turn broke some of my other bundle installs.

Futhermore, `bundle config build.zookeeper --with-cflags=...` does not fix the issue because those bundle CFLAG settings are passed only to the zookeeper gem itself, which (because of the way `ext/extconf.rb` is written) does not pass the provided cflags into the `zkc-3.4.5` build where the problem is really occurring.

So at the end of the day, the right solution seemed to be to patch the offending code, which leads to this one-liner PR.