### PR TITLE
add patch to compile with newer GCC versions.

### DIFF
--- a/ext/patches/zkc-3.4.5-overflow.patch
+++ b/ext/patches/zkc-3.4.5-overflow.patch
@@ -1,0 +1,11 @@
+--- zkc-3.4.5-orig/c/src/zookeeper.c	2020-12-01 14:16:08.000000000 +0100
++++ zkc-3.4.5/c/src/zookeeper.c	2020-12-01 14:16:08.000000000 +0100
+@@ -3411,7 +3411,7 @@
+
+ static const char* format_endpoint_info(const struct sockaddr_storage* ep)
+ {
+-    static char buf[128];
++    static char buf[134] = { 0 };
+     char addrstr[128];
+     void *inaddr;
+ #ifdef WIN32


### PR DESCRIPTION
this is needed to overcome some compile errors. e.g. http://mail-archives.apache.org/mod_mbox/zookeeper-dev/201903.mbox/%3CJIRA.13219713.1551831647000.49885.1551831960081@Atlassian.JIRA%3E

fix is borrowed from upstream https://github.com/apache/zookeeper/blob/master/zookeeper-client/zookeeper-client-c/src/zookeeper.c#L5101