### PR TITLE
Compile on MacOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'zk-server', '~> 1.0', :git => 'https://github.com/zk-ruby/zk-server.git'
 end
 
-# ffs, :platform appears to be COMLETELY BROKEN so we just DO THAT HERE
+# ffs, :platform appears to be COMPLETELY BROKEN so we just DO THAT HERE
 # ...BY HAND
 
 if RUBY_VERSION != '1.8.7' && !defined?(JRUBY_VERSION)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -69,8 +69,12 @@ Dir.chdir(HERE) do
     FileUtils.rm_f(Dir['**/._*'].select{|p| test(?f, p)})
 
     Dir.chdir(BUNDLE_PATH) do
+      configure_cflags = ''
+      configure_cflags += DEBUG_CFLAGS if ZK_DEBUG
+      configure_cflags += ' -Wno-nullability-completeness ' if RbConfig::CONFIG['target_vendor'] == 'apple'
+
       configure = "./configure --prefix=#{HERE} --with-pic --without-cppunit --disable-dependency-tracking #{$EXTRA_CONF} 2>&1"
-      configure = "env CFLAGS='#{DEBUG_CFLAGS}' #{configure}" if ZK_DEBUG
+      configure = "env CFLAGS='#{configure_cflags}' #{configure}" unless configure_cflags.empty?
 
       safe_sh(configure)
       safe_sh("make  2>&1")


### PR DESCRIPTION
When compiling under MacOS it fails:

> $ bundle i
> ...
> Installing zookeeper 1.4.11 with native extensions
> Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
> 
>     current directory: /Users/rafael.antunes/.rvm/gems/ruby-2.6.6/gems/zookeeper-1.4.11/ext
> /Users/rafael.antunes/.rvm/rubies/ruby-2.6.6/bin/ruby -I /Users/rafael.antunes/.rvm/rubies/ruby-2.6.6/lib/ruby/site_ruby/2.6.0 -r
> ./siteconf20210107-76708-18cv2g.rb extconf.rb
> Building zkc.
> tar xzf zkc-3.4.5.tar.gz 2>&1
> patch -p0 < patches/zkc-3.4.5-yosemite-htonl-fix.patch 2>&1
> patching file zkc-3.4.5/c/include/recordio.h
> patching file zkc-3.4.5/c/src/recordio.c
> patching file zkc-3.4.5/c/src/zookeeper.c
> patching file zkc-3.4.5/c/tests/ZKMocks.cc
> patch -p0 < patches/zkc-3.4.5-logging.patch 2>&1
> patching file zkc-3.4.5/c/src/zookeeper.c
> patch -p0 < patches/zkc-3.4.5-out-of-order-ping.patch 2>&1
> patching file zkc-3.4.5/c/src/zookeeper.c
> Hunk #3 succeeded at 2065 (offset 8 lines).
> Hunk #4 succeeded at 2182 (offset 8 lines).
> Hunk #5 succeeded at 2256 (offset 8 lines).
> patching file zkc-3.4.5/c/tests/TestOperations.cc
> ./configure --prefix=/Users/rafael.antunes/.rvm/gems/ruby-2.6.6/gems/zookeeper-1.4.11/ext --with-pic --without-cppunit
> --disable-dependency-tracking  2>&1
> checking for doxygen... no
> checking for perl... /usr/local/bin/perl
> checking for dot... no
> checking for a BSD-compatible install... /usr/local/bin/ginstall -c
> checking whether build environment is sane... yes
> checking for gawk... no
> checking for mawk... no
> checking for nawk... no
> checking for awk... awk
> checking whether make sets $(MAKE)... yes
> checking for generated/zookeeper.jute.c... yes
> checking for generated/zookeeper.jute.h... yes
> checking for gcc... gcc
> checking for C compiler default output file name... a.out
> checking whether the C compiler works... yes
> checking whether we are cross compiling... no
> checking for suffix of executables... 
> checking for suffix of object files... o
> checking whether we are using the GNU C compiler... yes
> checking whether gcc accepts -g... yes
> checking for gcc option to accept ANSI C... none needed
> checking for style of include used by make... GNU
> checking dependency style of gcc... none
> checking whether gcc and cc understand -c and -o together... yes
> checking for g++... g++
> checking whether we are using the GNU C++ compiler... yes
> checking whether g++ accepts -g... yes
> checking dependency style of g++... none
> checking for a BSD-compatible install... /usr/local/bin/ginstall -c
> checking whether ln -s works... yes
> checking build system type... i686-apple-darwin19.6.0
> checking host system type... i686-apple-darwin19.6.0
> checking for a sed that does not truncate output... /usr/bin/sed
> checking for egrep... grep -E
> checking for ld used by gcc... /Library/Developer/CommandLineTools/usr/bin/ld
> checking if the linker (/Library/Developer/CommandLineTools/usr/bin/ld) is GNU ld... no
> checking for /Library/Developer/CommandLineTools/usr/bin/ld option to reload object files... -r
> checking for BSD-compatible nm... /usr/bin/nm -B
> checking how to recognise dependent libraries... pass_all
> checking how to run the C preprocessor... gcc -E
> checking for ANSI C header files... no
> checking for sys/types.h... yes
> checking for sys/stat.h... yes
> checking for stdlib.h... yes
> checking for string.h... yes
> checking for memory.h... yes
> checking for strings.h... yes
> checking for inttypes.h... yes
> checking for stdint.h... yes
> checking for unistd.h... yes
> checking dlfcn.h usability... yes
> checking dlfcn.h presence... yes
> checking for dlfcn.h... yes
> checking how to run the C++ preprocessor... g++ -E
> checking for g77... no
> checking for f77... no
> checking for xlf... no
> checking for frt... no
> checking for pgf77... no
> checking for fort77... no
> checking for fl32... no
> checking for af77... no
> checking for f90... no
> checking for xlf90... no
> checking for pgf90... no
> checking for epcf90... no
> checking for f95... no
> checking for fort... no
> checking for xlf95... no
> checking for ifc... no
> checking for efc... no
> checking for pgf95... no
> checking for lf95... no
> checking for gfortran... no
> checking whether we are using the GNU Fortran 77 compiler... no
> checking whether  accepts -g... no
> checking the maximum length of command line arguments... 196608
> checking command to parse /usr/bin/nm -B output from gcc object... rm: conftest.dSYM: is a directory
> ok
> checking for objdir... .libs
> checking for ar... ar
> checking for ranlib... ranlib
> checking for strip... strip
> rm: conftest.dSYM: is a directory
> rm: conftest.dSYM: is a directory
> checking if gcc supports -fno-rtti -fno-exceptions... rm: conftest.dSYM: is a directory
> yes
> checking for gcc option to produce PIC... -fno-common
> checking if gcc PIC flag -fno-common works... rm: conftest.dSYM: is a directory
> yes
> checking if gcc static flag -static works... rm: conftest.dSYM: is a directory
> no
> checking if gcc supports -c -o file.o... rm: conftest.dSYM: is a directory
> yes
> checking whether the gcc linker (/Library/Developer/CommandLineTools/usr/bin/ld) supports shared libraries... yes
> checking dynamic linker characteristics... darwin19.6.0 dyld
> checking how to hardcode library paths into programs... immediate
> checking whether stripping libraries is possible... yes
> checking if libtool supports shared libraries... yes
> checking whether to build shared libraries... yes
> checking whether to build static libraries... yes
> configure: creating libtool
> appending configuration tag "CXX" to libtool
> rm: conftest.dSYM: is a directory
> rm: conftest.dSYM: is a directory
> checking for ld used by g++... /Library/Developer/CommandLineTools/usr/bin/ld
> checking if the linker (/Library/Developer/CommandLineTools/usr/bin/ld) is GNU ld... no
> checking whether the g++ linker (/Library/Developer/CommandLineTools/usr/bin/ld) supports shared libraries... yes
> checking for g++ option to produce PIC... -fno-common
> checking if g++ PIC flag -fno-common works... rm: conftest.dSYM: is a directory
> yes
> checking if g++ static flag -static works... rm: conftest.dSYM: is a directory
> no
> checking if g++ supports -c -o file.o... rm: conftest.dSYM: is a directory
> yes
> checking whether the g++ linker (/Library/Developer/CommandLineTools/usr/bin/ld) supports shared libraries... yes
> checking dynamic linker characteristics... darwin19.6.0 dyld
> checking how to hardcode library paths into programs... immediate
> appending configuration tag "F77" to libtool
> checking for pthread_mutex_lock in -lpthread... yes
> configure: building with SyncAPI support
> checking for ANSI C header files... (cached) no
> checking arpa/inet.h usability... yes
> checking arpa/inet.h presence... yes
> checking for arpa/inet.h... yes
> checking fcntl.h usability... yes
> checking fcntl.h presence... yes
> checking for fcntl.h... yes
> checking netdb.h usability... yes
> checking netdb.h presence... yes
> checking for netdb.h... yes
> checking netinet/in.h usability... yes
> checking netinet/in.h presence... yes
> checking for netinet/in.h... yes
> checking for stdlib.h... (cached) yes
> checking for string.h... (cached) yes
> checking sys/socket.h usability... yes
> checking sys/socket.h presence... yes
> checking for sys/socket.h... yes
> checking sys/time.h usability... yes
> checking sys/time.h presence... yes
> checking for sys/time.h... yes
> checking for unistd.h... (cached) yes
> checking sys/utsname.h usability... yes
> checking sys/utsname.h presence... yes
> checking for sys/utsname.h... yes
> checking for an ANSI C-conforming const... yes
> checking for inline... inline
> checking whether time.h and sys/time.h may both be included... yes
> checking for nfds_t... yes
> checking whether to enable ipv6... no
> checking for getcwd... yes
> checking for gethostbyname... yes
> checking for gethostname... yes
> checking for getlogin... yes
> checking for getpwuid_r... yes
> checking for gettimeofday... yes
> checking for getuid... yes
> checking for memmove... yes
> checking for memset... yes
> checking for poll... yes
> checking for socket... yes
> checking for strchr... yes
> checking for strdup... yes
> checking for strerror... yes
> checking for strtol... yes
> configure: creating ./config.status
> config.status: creating Makefile
> config.status: creating config.h
> config.status: executing depfiles commands
> make  2>&1
> /Library/Developer/CommandLineTools/usr/bin/make  all-am
> /bin/sh ./libtool --tag=CC --mode=compile gcc -DHAVE_CONFIG_H -I. -I. -I.  -I./include -I./tests -I./generated  -Wall -Werror  -g
> -O2 -D_GNU_SOURCE -c -o zookeeper.lo `test -f 'src/zookeeper.c' || echo './'`src/zookeeper.c
> mkdir .libs
> gcc -DHAVE_CONFIG_H -I. -I. -I. -I./include -I./tests -I./generated -Wall -Werror -g -O2 -D_GNU_SOURCE -c src/zookeeper.c 
> -fno-common -DPIC -o .libs/zookeeper.o
> In file included from src/zookeeper.c:27:
> In file included from ./include/zookeeper.h:22:
> /usr/local/include/stdlib.h:134:25: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> double   atof(const char *);
>                          ^
> /usr/local/include/stdlib.h:134:25: note: insert '_Nullable' if the pointer may be null
> double   atof(const char *);
>                          ^
>                           _Nullable
> /usr/local/include/stdlib.h:134:25: note: insert '_Nonnull' if the pointer should never be null
> double   atof(const char *);
>                          ^
>                           _Nonnull
> /usr/local/include/stdlib.h:135:22: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> int      atoi(const char *);
>                          ^
> /usr/local/include/stdlib.h:135:22: note: insert '_Nullable' if the pointer may be null
> int      atoi(const char *);
>                          ^
>                           _Nullable
> /usr/local/include/stdlib.h:135:22: note: insert '_Nonnull' if the pointer should never be null
> int      atoi(const char *);
>                          ^
>                           _Nonnull
> /usr/local/include/stdlib.h:136:23: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> long     atol(const char *);
>                          ^
> /usr/local/include/stdlib.h:136:23: note: insert '_Nullable' if the pointer may be null
> long     atol(const char *);
>                          ^
>                           _Nullable
> /usr/local/include/stdlib.h:136:23: note: insert '_Nonnull' if the pointer should never be null
> long     atol(const char *);
>                          ^
>                           _Nonnull
> /usr/local/include/stdlib.h:139:20: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
>          atoll(const char *);
>                           ^
> /usr/local/include/stdlib.h:139:20: note: insert '_Nullable' if the pointer may be null
>          atoll(const char *);
>                           ^
>                            _Nullable
> /usr/local/include/stdlib.h:139:20: note: insert '_Nonnull' if the pointer should never be null
>          atoll(const char *);
>                           ^
>                            _Nonnull
> /usr/local/include/stdlib.h:141:26: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>                             ^
> /usr/local/include/stdlib.h:141:26: note: insert '_Nullable' if the pointer may be null
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>                             ^
>                               _Nullable 
> /usr/local/include/stdlib.h:141:26: note: insert '_Nonnull' if the pointer should never be null
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>                             ^
>                               _Nonnull 
> /usr/local/include/stdlib.h:141:45: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>                                                ^
> /usr/local/include/stdlib.h:141:45: note: insert '_Nullable' if the pointer may be null
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>                                                ^
>                                                  _Nullable 
> /usr/local/include/stdlib.h:141:45: note: insert '_Nonnull' if the pointer should never be null
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>                                                ^
>                                                  _Nonnull 
> /usr/local/include/stdlib.h:142:59: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
>             size_t __width, int (* _Nonnull __compar)(const void *, const void *));
>                                                                  ^
> /usr/local/include/stdlib.h:142:59: note: insert '_Nullable' if the pointer may be null
>             size_t __width, int (* _Nonnull __compar)(const void *, const void *));
>                                                                  ^
>                                                                   _Nullable
> /usr/local/include/stdlib.h:142:59: note: insert '_Nonnull' if the pointer should never be null
>             size_t __width, int (* _Nonnull __compar)(const void *, const void *));
>                                                                  ^
>                                                                   _Nonnull
> /usr/local/include/stdlib.h:142:73: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
>             size_t __width, int (* _Nonnull __compar)(const void *, const void *));
>                                                                                ^
> /usr/local/include/stdlib.h:142:73: note: insert '_Nullable' if the pointer may be null
>             size_t __width, int (* _Nonnull __compar)(const void *, const void *));
>                                                                                ^
>                                                                                 _Nullable
> /usr/local/include/stdlib.h:142:73: note: insert '_Nonnull' if the pointer should never be null
>             size_t __width, int (* _Nonnull __compar)(const void *, const void *));
>                                                                                ^
>                                                                                 _Nonnull
> /usr/local/include/stdlib.h:141:6: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>         ^
> /usr/local/include/stdlib.h:141:6: note: insert '_Nullable' if the pointer may be null
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>         ^
>           _Nullable 
> /usr/local/include/stdlib.h:141:6: note: insert '_Nonnull' if the pointer should never be null
> void    *bsearch(const void *__key, const void *__base, size_t __nel,
>         ^
>           _Nonnull 
> /usr/local/include/stdlib.h:147:25: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> char    *getenv(const char *);
>                            ^
> /usr/local/include/stdlib.h:147:25: note: insert '_Nullable' if the pointer may be null
> char    *getenv(const char *);
>                            ^
>                             _Nullable
> /usr/local/include/stdlib.h:147:25: note: insert '_Nonnull' if the pointer should never be null
> char    *getenv(const char *);
>                            ^
>                             _Nonnull
> /usr/local/include/stdlib.h:147:6: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> char    *getenv(const char *);
>         ^
> /usr/local/include/stdlib.h:147:6: note: insert '_Nullable' if the pointer may be null
> char    *getenv(const char *);
>         ^
>           _Nullable 
> /usr/local/include/stdlib.h:147:6: note: insert '_Nonnull' if the pointer should never be null
> char    *getenv(const char *);
>         ^
>           _Nonnull 
> /usr/local/include/stdlib.h:156:23: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> int      mblen(const char *__s, size_t __n);
>                           ^
> /usr/local/include/stdlib.h:156:23: note: insert '_Nullable' if the pointer may be null
> int      mblen(const char *__s, size_t __n);
>                           ^
>                             _Nullable 
> /usr/local/include/stdlib.h:156:23: note: insert '_Nonnull' if the pointer should never be null
> int      mblen(const char *__s, size_t __n);
>                           ^
>                             _Nonnull 
> /usr/local/include/stdlib.h:157:26: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> size_t   mbstowcs(wchar_t * __restrict , const char * __restrict, size_t);
>                           ^
> /usr/local/include/stdlib.h:157:26: note: insert '_Nullable' if the pointer may be null
> size_t   mbstowcs(wchar_t * __restrict , const char * __restrict, size_t);
>                           ^
>                             _Nullable
> /usr/local/include/stdlib.h:157:26: note: insert '_Nonnull' if the pointer should never be null
> size_t   mbstowcs(wchar_t * __restrict , const char * __restrict, size_t);
>                           ^
>                             _Nonnull
> /usr/local/include/stdlib.h:157:52: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> size_t   mbstowcs(wchar_t * __restrict , const char * __restrict, size_t);
>                                                     ^
> /usr/local/include/stdlib.h:157:52: note: insert '_Nullable' if the pointer may be null
> size_t   mbstowcs(wchar_t * __restrict , const char * __restrict, size_t);
>                                                     ^
>                                                       _Nullable
> /usr/local/include/stdlib.h:157:52: note: insert '_Nonnull' if the pointer should never be null
> size_t   mbstowcs(wchar_t * __restrict , const char * __restrict, size_t);
>                                                     ^
>                                                       _Nonnull
> /usr/local/include/stdlib.h:158:21: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> int      mbtowc(wchar_t * __restrict, const char * __restrict, size_t);
>                         ^
> /usr/local/include/stdlib.h:158:21: note: insert '_Nullable' if the pointer may be null
> int      mbtowc(wchar_t * __restrict, const char * __restrict, size_t);
>                         ^
>                           _Nullable
> /usr/local/include/stdlib.h:158:21: note: insert '_Nonnull' if the pointer should never be null
> int      mbtowc(wchar_t * __restrict, const char * __restrict, size_t);
>                         ^
>                           _Nonnull
> /usr/local/include/stdlib.h:158:46: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> int      mbtowc(wchar_t * __restrict, const char * __restrict, size_t);
>                                                  ^
> /usr/local/include/stdlib.h:158:46: note: insert '_Nullable' if the pointer may be null
> int      mbtowc(wchar_t * __restrict, const char * __restrict, size_t);
>                                                  ^
>                                                    _Nullable
> /usr/local/include/stdlib.h:158:46: note: insert '_Nonnull' if the pointer should never be null
> int      mbtowc(wchar_t * __restrict, const char * __restrict, size_t);
>                                                  ^
>                                                    _Nonnull
> /usr/local/include/stdlib.h:160:18: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
> void     qsort(void *__base, size_t __nel, size_t __width,
>                     ^
> /usr/local/include/stdlib.h:160:18: note: insert '_Nullable' if the pointer may be null
> void     qsort(void *__base, size_t __nel, size_t __width,
>                     ^
>                       _Nullable 
> /usr/local/include/stdlib.h:160:18: note: insert '_Nonnull' if the pointer should never be null
> void     qsort(void *__base, size_t __nel, size_t __width,
>                     ^
>                       _Nonnull 
> /usr/local/include/stdlib.h:161:43: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
>             int (* _Nonnull __compar)(const void *, const void *));
>                                                  ^
> /usr/local/include/stdlib.h:161:43: note: insert '_Nullable' if the pointer may be null
>             int (* _Nonnull __compar)(const void *, const void *));
>                                                  ^
>                                                   _Nullable
> /usr/local/include/stdlib.h:161:43: note: insert '_Nonnull' if the pointer should never be null
>             int (* _Nonnull __compar)(const void *, const void *));
>                                                  ^
>                                                   _Nonnull
> /usr/local/include/stdlib.h:161:57: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or
> _Null_unspecified) [-Werror,-Wnullability-completeness]
>             int (* _Nonnull __compar)(const void *, const void *));
>                                                                ^
> /usr/local/include/stdlib.h:161:57: note: insert '_Nullable' if the pointer may be null
>             int (* _Nonnull __compar)(const void *, const void *));
>                                                                ^
>                                                                 _Nullable
> /usr/local/include/stdlib.h:161:57: note: insert '_Nonnull' if the pointer should never be null
>             int (* _Nonnull __compar)(const void *, const void *));
>                                                                ^
>                                                                 _Nonnull
> fatal error: too many errors emitted, stopping now [-ferror-limit=]
> 20 errors generated.
> make[1]: *** [zookeeper.lo] Error 1
> make: *** [all] Error 2
> *** extconf.rb failed ***
> Could not create Makefile due to some reason, probably lack of necessary
> libraries and/or headers.  Check the mkmf.log file for more details.  You may
> need configuration options.
> 
> Provided configuration options:
> 	--with-opt-dir
> 	--with-opt-include
> 	--without-opt-include=${opt-dir}/include
> 	--with-opt-lib
> 	--without-opt-lib=${opt-dir}/lib
> 	--with-make-prog
> 	--without-make-prog
> 	--srcdir=.
> 	--curdir
> 	--ruby=/Users/rafael.antunes/.rvm/rubies/ruby-2.6.6/bin/$(RUBY_BASE_NAME)
> extconf.rb:51:in `safe_sh': command failed! make  2>&1 (RuntimeError)
> 	from extconf.rb:76:in `block (2 levels) in <main>'
> 	from extconf.rb:71:in `chdir'
> 	from extconf.rb:71:in `block in <main>'
> 	from extconf.rb:55:in `chdir'
> 	from extconf.rb:55:in `<main>'
> 
> extconf failed, exit code 1
> 
> Gem files will remain installed in /Users/rafael.antunes/.rvm/gems/ruby-2.6.6/gems/zookeeper-1.4.11 for inspection.
> Results logged to /Users/rafael.antunes/.rvm/gems/ruby-2.6.6/extensions/x86_64-darwin-19/2.6.0/zookeeper-1.4.11/gem_make.out
> 
> An error occurred while installing zookeeper (1.4.11), and Bundler cannot continue.
> Make sure that `gem install zookeeper -v '1.4.11' --source 'https://rubygems.org/'` succeeds before bundling.
> 
> In Gemfile:
>   zk was resolved to 1.9.6, which depends on
>     zookeeper