### PR TITLE
1.5.0 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v1.5.0
+  * (housekeeping) Moves build to Github Actions from TravisCI
+  * (housekeeping) Drops build support for MRI Ruby < 2.5 and other rubies
+  * Build on Ruby 3 (#99) (h/t: @malmckay)
+  * Build on MacOS (#98) (h/t: @malmckay)
+  * Work around compiler errors on newer versions of gcc (#97) (h/t: @nickmarden)
+  * Fix a typo on a has_key (#83) (h/t: @lexspoon)
+  * Adds support macOS dylib (#86) (h/t: @pftg)
+  * Fix compilation on ARM (#82) (h/t: @cdonati)
+
 v1.4.11
   * backported fix for ZOOKEEPER-2253 by @chchen - #76
 

--- a/README.markdown
+++ b/README.markdown
@@ -11,10 +11,6 @@ For a higher-level interface with a more convenient API and features such as loc
 
 As of 1.1.0, this library is fork-safe (which was not easy to accomplish). This means you can use it without worry in unicorn, resque, and whatever other fork-philic frameworks you sick little monkeys are using this week. The only rule is that after a fork(), you need to call `#reopen` on the client ASAP, because if you try to peform any other action, an exception will be raised. Other than that, there is no special action that is needed in the parent.
 
-## Big Plans for 1.0 ##
-
-The 1.0 release will feature a reorganization of the heirarchy. There will be a single top-level `Zookeeper` namespace (as opposed to the current layout, with 5-6 different top-level constants), and for the next several releases, there will be a backwards compatible require for users that still need to use the old names.
-
 ## License
 
 Copyright 2008 Phillip Pearson, and 2010 Twitter, Inc.
@@ -28,26 +24,6 @@ Portions contributed to the open source community by HPDC, L.P.
 ## Install
 
 sudo gem install zookeeper
-
-### rbenv is awesome
-
-UPDATE: this appears to have been fixed by @eric in [this patch](http://git.io/PEPgnA). If you use rbenv, please report any issues, but I believe it should work now.
-
-Let me start out by saying I prefer rvm, and that I really don't know a whole lot about linking on OS X. Or Linux. Any suggestions or constructive insults would be greatly appreciated if you have insight into what i'm doing wrong here.
-
-So, it seems that [ruby-build][] doesn't use `--enable-shared` by default. I'm told this is for speed.
-
-If you run into problems with installing this gem (specifically with linking ex. `Undefined symbols for architecture x86_64`) and you're using rbenv, for now you need to ensure that your ruby was built with `--enable-shared`. I'm sorry for the inconvenience. (no, really)
-
-```shell
-~ $ CONFIGURE_OPTS='--enable-shared --disable-install-doc' rbenv install 1.9.3-p194
-```
-
-[ruby-build]: https://github.com/sstephenson/ruby-build
-
-### A note for REE users
-
-The zookeeper client is required to send a heartbeat packet every N seconds to the server. If it misses its deadline 3 times in a row, the session will be lost. The way the client is implemented in versions `>= 1.2`, a *ruby* thread acts as the event thread (this was necessary to provide a fork-safe client with a parent process that is able to preserve state). Some users have reported issues where under load in "massive codebases," they have problems where calls will time out. Given the nature of the thread scheduler in 1.8, one should be careful if upgrading from `0.4.4` to `>= 1.2`.
 
 ## Usage
 

--- a/lib/zookeeper/version.rb
+++ b/lib/zookeeper/version.rb
@@ -1,4 +1,4 @@
 module Zookeeper
-  VERSION = '1.4.11'
+  VERSION = '1.5.0'
   DRIVER_VERSION = '3.4.5'
 end

--- a/zookeeper.gemspec
+++ b/zookeeper.gemspec
@@ -6,13 +6,21 @@ Gem::Specification.new do |s|
   s.name        = 'zookeeper'
   s.version     = Zookeeper::VERSION
 
-  s.authors     = ["Phillip Pearson", "Eric Maland", "Evan Weaver", "Brian Wickman", "Neil Conway", "Jonathan D. Simms"]
+  s.authors     = [
+    "Phillip Pearson", 
+    "Eric Maland", 
+    "Evan Weaver", 
+    "Brian Wickman", 
+    "Neil Conway",
+    "Jonathan D. Simms",
+    "Mal McKay",
+  ]
   s.email       = ["slyphon@gmail.com"]
   s.summary     = %q{Apache ZooKeeper driver for Rubies}
   s.description = <<-EOS
 A low-level multi-Ruby wrapper around the ZooKeeper API bindings. For a
 friendlier interface, see http://github.com/slyphon/zk. Currently supported:
-MRI: {1.8.7, 1.9.2, 1.9.3}, JRuby: ~> 1.6.7, Rubinius: 2.0.testing, REE 1.8.7.
+MRI: {2.5, 2.6, 2.7, 3.0}, JRuby: ~> 9.2.x.x
 
 This library uses version #{Zookeeper::DRIVER_VERSION} of zookeeper bindings.
 


### PR DESCRIPTION
I'm choosing to bump the version to 1.5.0 because we've had to drop support for a number of rubies