### PR TITLE
[Ruby3.2] Replace File.exists? with File.file?

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ release_ops_path = File.expand_path('../releaseops/lib', __FILE__)
 # we use a submodule because it doesn't depend on anything else (*cough* bundler)
 # and can be shared across projects
 #
-if File.exists?(release_ops_path)
+if File.file?(release_ops_path)
   require File.join(release_ops_path, 'releaseops')
 
   # sets up the multi-ruby zk:test_all rake tasks

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -4,7 +4,7 @@ ZKRB_WRAPPER = %w[zkrb_wrapper.c zkrb_wrapper.h]
 
 namespace :zkrb do
   task :clean do
-    if File.exists?('Makefile')
+    if File.file?('Makefile')
       sh 'make clean'
       rm 'Makefile' # yep, regenerate this
     else

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -58,7 +58,7 @@ Dir.chdir(HERE) do
   else
     puts "Building zkc."
 
-    unless File.exists?('c')
+    unless File.file?('c')
       safe_sh "tar xzf #{BUNDLE} 2>&1"
       PATCHES.each do |patch|
         safe_sh "patch -p0 < #{patch} 2>&1"
@@ -87,7 +87,7 @@ Dir.chdir("#{HERE}/lib") do
     %w[a la dylib].each do |ext|
       origin_lib_name = "libzookeeper_#{stmt}.#{ext}"
       dest_lib_name = "libzookeeper_#{stmt}_gem.#{ext}"
-      system("cp -f #{origin_lib_name} #{dest_lib_name}") if File.exists?(origin_lib_name)
+      system("cp -f #{origin_lib_name} #{dest_lib_name}") if File.file?(origin_lib_name)
     end
   end
 end

--- a/lib/zookeeper/version.rb
+++ b/lib/zookeeper/version.rb
@@ -1,4 +1,4 @@
 module Zookeeper
-  VERSION = '1.5.3'
+  VERSION = '1.5.4'
   DRIVER_VERSION = '3.4.5'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'rubygems'
 
 release_ops_path = File.expand_path('../../releaseops/lib', __FILE__)
 
-if File.exists?(release_ops_path)
+if File.file?(release_ops_path)
   require File.join(release_ops_path, 'releaseops')
   ReleaseOps::SimpleCov.maybe_start
 end


### PR DESCRIPTION
Due to https://bugs.ruby-lang.org/issues/17391, `File.exists?` no longer exists in ruby 3.2, thus breaking support.

This commit simply swaps `File.exists?` with `File.file?`