### PR TITLE
Fix loading on Ruby 3.2

### DIFF
--- a/ext/c_zookeeper.rb
+++ b/ext/c_zookeeper.rb
@@ -2,9 +2,14 @@ Zookeeper.require_lib(
   'zookeeper/logger',
   'zookeeper/common',
   'zookeeper/constants',
-  'zookeeper/exceptions', # zookeeper_c depends on exceptions defined in here
-  'zookeeper_c',
+  'zookeeper/exceptions' # zookeeper_c depends on exceptions defined in here
 )
+
+begin
+    Zookeeper.require_root 'ext/zookeeper_c'
+rescue LoadError # Rubygems 3.4+ cleans up build artifacts in the ext/ directory.
+    Zookeeper.require_lib 'zookeeper_c'
+end
 
 module Zookeeper
 # NOTE: this class extending (opening) the class defined in zkrb.c

--- a/ext/c_zookeeper.rb
+++ b/ext/c_zookeeper.rb
@@ -2,16 +2,9 @@ Zookeeper.require_lib(
   'zookeeper/logger',
   'zookeeper/common',
   'zookeeper/constants',
-  'zookeeper/exceptions' # zookeeper_c depends on exceptions defined in here
+  'zookeeper/exceptions', # zookeeper_c depends on exceptions defined in here
+  'zookeeper_c',
 )
-
-begin
-    Zookeeper.require_root 'ext/zookeeper_c'
-rescue LoadError # Rubygems 3.4+ cleans up build artifacts in the ext/ directory.
-    Zookeeper.require_lib 'zookeeper_c'
-end
-
-# require File.expand_path('../zookeeper_c', __FILE__)
 
 module Zookeeper
 # NOTE: this class extending (opening) the class defined in zkrb.c

--- a/ext/c_zookeeper.rb
+++ b/ext/c_zookeeper.rb
@@ -5,7 +5,11 @@ Zookeeper.require_lib(
   'zookeeper/exceptions' # zookeeper_c depends on exceptions defined in here
 )
 
-Zookeeper.require_root 'ext/zookeeper_c'
+begin
+    Zookeeper.require_root 'ext/zookeeper_c'
+rescue LoadError # Rubygems 3.4+ cleans up build artifacts in the ext/ directory.
+    Zookeeper.require_lib 'zookeeper_c'
+end
 
 # require File.expand_path('../zookeeper_c', __FILE__)
 


### PR DESCRIPTION
RubyGems 3.4 will now clean up built artifacts after building extensions. Our previous require loaded the artifact from the ext directory. 

This PR rescues from this load failure and loads the .bundle/.so instead. I briefly looked loading from the correct place, without this try/catch, that would take more work.